### PR TITLE
Chore/add exclude flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,6 @@ jobs:
           secret_name: <secret-name>
           json_file_path: path/to/json/secrets.json
           dry_run: true # Default false
+          show_values: false # If true secret values will be displayed on action logs (default false)
+          exclude: '^_' # Regular expression that excludes the matching keys to be synced (default '^_')
 ```

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,10 @@ inputs:
   dry_run:
     description: "Dry run mode (preview changes without modifying the secret)"
     required: false
-    default: "false" # Set the default value to 'false'
+    default: "false"
+  exclude:
+    description: "List of regular expressions that determines if a secret key should be excluded from sync"
+    required: false
 
 outputs:
   changes:

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "Dry run mode (preview changes without modifying the secret)"
     required: false
     default: "false"
+  show_values:
+    description: "Dry run mode (preview changes without modifying the secret)"
+    required: false
+    default: "false"
   exclude:
     description: "List of regular expressions that determines if a secret key should be excluded from sync"
     required: false

--- a/index.js
+++ b/index.js
@@ -2,15 +2,13 @@ import core from "@actions/core";
 import Action from "./src/action/Action.js";
 
 const getAction = () => {
-  const exclude = core.getInput("exclude").split(",");
-
   return new Action(
     core.getInput("aws_access_key_id"),
     core.getInput("aws_secret_access_key"),
     core.getInput("aws_region"),
     core.getInput("secret_name"),
     core.getInput("json_file_path"),
-    exclude,
+    core.getInput("exclude"),
   );
 };
 

--- a/index.js
+++ b/index.js
@@ -9,12 +9,13 @@ const getAction = () => {
     core.getInput("secret_name"),
     core.getInput("json_file_path"),
     core.getInput("exclude"),
+    core.getBooleanInput("show_values"),
   );
 };
 
 const run = async () => {
   try {
-    const dryRun = core.getInput("dry_run") === "true";
+    const dryRun = core.getBooleanInput("dry_run");
 
     const changeSet = await getAction().run();
 

--- a/index.js
+++ b/index.js
@@ -1,19 +1,24 @@
 import core from "@actions/core";
 import Action from "./src/action/Action.js";
 
-async function run() {
+const getAction = () => {
+  const exclude = core.getInput("exclude").split(",");
+
+  return new Action(
+    core.getInput("aws_access_key_id"),
+    core.getInput("aws_secret_access_key"),
+    core.getInput("aws_region"),
+    core.getInput("secret_name"),
+    core.getInput("json_file_path"),
+    exclude,
+  );
+};
+
+const run = async () => {
   try {
     const dryRun = core.getInput("dry_run") === "true";
 
-    const action = new Action(
-      core.getInput("aws_access_key_id"),
-      core.getInput("aws_secret_access_key"),
-      core.getInput("aws_region"),
-      core.getInput("secret_name"),
-      core.getInput("json_file_path"),
-    );
-
-    const changeSet = await action.run();
+    const changeSet = await getAction().run();
 
     for (const desc of changeSet.changeDesc()) {
       core.info(desc);
@@ -21,10 +26,11 @@ async function run() {
 
     if (!dryRun) {
       await changeSet.apply();
+      core.info("Secrets has been synced!!");
     }
   } catch (error) {
     core.setFailed(error.message);
   }
-}
+};
 
 run();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "sync-secrets-manager",
-  "version": "0.0.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sync-secrets-manager",
-      "version": "0.0.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@aws-sdk/client-secrets-manager": "^3.425.0",
+        "chalk": "^5.3.0",
         "fs": "^0.0.1-security",
         "lodash": "^4.17.21"
       },
@@ -1642,16 +1643,11 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -2266,6 +2262,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/espree": {
@@ -3343,6 +3355,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/loupe": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "npx eslint --fix .",
     "format": "npx prettier --write .",
-    "test": "mocha ./tests/**/*.test.js",
+    "test": "FORCE_COLOR=0 mocha ./tests/**/*.test.js",
     "pre-commit": "pre-commit install --hook-type commit-msg"
   },
   "repository": {
@@ -41,6 +41,7 @@
   "dependencies": {
     "@actions/core": "^1.10.1",
     "@aws-sdk/client-secrets-manager": "^3.425.0",
+    "chalk": "^5.3.0",
     "fs": "^0.0.1-security",
     "lodash": "^4.17.21"
   }

--- a/src/action/Action.js
+++ b/src/action/Action.js
@@ -1,5 +1,4 @@
 import fs from "fs";
-import lodash from "lodash";
 
 import SecretsManager from "../secrets-manager/SecretsManager.js";
 import ChangeSet from "./ChangeSet.js";
@@ -14,21 +13,32 @@ export default class Action {
   /**
    * Creates a new Action instance.
    *
-   * @param {string} keyId - The AWS access key ID.
-   * @param {string} secretKey - The AWS secret access key.
-   * @param {string} region - The AWS region.
-   * @param {string} secretName - The name of the secret in AWS Secrets Manager.
-   * @param {string} jsonFile - The path to the JSON file containing the new secret values.
-   * @param {string} skipPattern - A list of regular expressions that eval keys of the json file and if match,
+   * @param {string} keyId The AWS access key ID.
+   * @param {string} secretKey The AWS secret access key.
+   * @param {string} region The AWS region.
+   * @param {string} secretName The name of the secret in AWS Secrets Manager.
+   * @param {string} jsonFile The path to the JSON file containing the new secret values.
+   * @param {string} skipPattern A regular expression that eval keys of the json file and if match,
    *        that key should be omitted
+   * @param {string} showValues If this flag is set to true all secret values will be displayed on logs,
+   *        if false, a place holder will be displayed.
    *
    * @throws {Error} Throws an error if any required parameter is missing or if the JSON file doesn't exist.
    */
-  constructor(keyId, secretKey, region, secretName, jsonFile, skipPattern) {
+  constructor(
+    keyId,
+    secretKey,
+    region,
+    secretName,
+    jsonFile,
+    skipPattern,
+    showValues = false,
+  ) {
     this.#validateData(keyId, secretKey, region, secretName, jsonFile);
 
     this.jsonFile = jsonFile;
     this.skipPattern = skipPattern || defaultSkipPattern;
+    this.showValues = showValues;
 
     this.smClient = new SecretsManager(keyId, secretKey, region, secretName);
   }
@@ -47,6 +57,7 @@ export default class Action {
       newSecretData,
       existingSecretData,
       this.skipPattern,
+      this.showValues,
     );
   }
 

--- a/src/action/Action.js
+++ b/src/action/Action.js
@@ -4,7 +4,7 @@ import lodash from "lodash";
 import SecretsManager from "../secrets-manager/SecretsManager.js";
 import ChangeSet from "./ChangeSet.js";
 
-const skipPatterns = ["^_"];
+const defaultSkipPattern = "^_";
 
 /**
  * Action is a class representing an action to synchronize secrets with AWS Secrets Manager.
@@ -19,23 +19,16 @@ export default class Action {
    * @param {string} region - The AWS region.
    * @param {string} secretName - The name of the secret in AWS Secrets Manager.
    * @param {string} jsonFile - The path to the JSON file containing the new secret values.
-   * @param {Array<string>} skipPatterns - A list of regular expressions that eval keys of the json file and if match,
+   * @param {string} skipPattern - A list of regular expressions that eval keys of the json file and if match,
    *        that key should be omitted
    *
    * @throws {Error} Throws an error if any required parameter is missing or if the JSON file doesn't exist.
    */
-  constructor(
-    keyId,
-    secretKey,
-    region,
-    secretName,
-    jsonFile,
-    skipPatterns = [],
-  ) {
+  constructor(keyId, secretKey, region, secretName, jsonFile, skipPattern) {
     this.#validateData(keyId, secretKey, region, secretName, jsonFile);
 
     this.jsonFile = jsonFile;
-    this.skipPatterns = this.#getSkipPatterns(skipPatterns);
+    this.skipPattern = skipPattern || defaultSkipPattern;
 
     this.smClient = new SecretsManager(keyId, secretKey, region, secretName);
   }
@@ -53,7 +46,7 @@ export default class Action {
       this.smClient,
       newSecretData,
       existingSecretData,
-      this.skipPatterns,
+      this.skipPattern,
     );
   }
 
@@ -93,13 +86,5 @@ export default class Action {
     if (!fs.existsSync(jsonFile)) {
       throw new Error(`JSON file does not exist at path: ${jsonFile}`);
     }
-  }
-
-  #getSkipPatterns(skip) {
-    if (lodash.isArray(skip) && skip.length > 0) {
-      return skipPatterns.concat(skip);
-    }
-
-    return skipPatterns;
   }
 }

--- a/src/action/ChangeSet.js
+++ b/src/action/ChangeSet.js
@@ -1,4 +1,5 @@
 import core from "@actions/core";
+import lodash from "lodash";
 
 import SecretsManager from "../secrets-manager/SecretsManager.js";
 
@@ -119,6 +120,10 @@ export default class ChangeSet {
    */
   #shouldSkip(key) {
     for (let regexp of this.#skipPatterns) {
+      if (lodash.isEmpty(regexp)) {
+        continue;
+      }
+
       let exp = new RegExp(regexp);
 
       if (exp.test(key)) {

--- a/src/action/ChangeSet.js
+++ b/src/action/ChangeSet.js
@@ -1,3 +1,5 @@
+import core from "@actions/core";
+
 import SecretsManager from "../secrets-manager/SecretsManager.js";
 
 /**
@@ -120,6 +122,7 @@ export default class ChangeSet {
       let exp = new RegExp(regexp);
 
       if (exp.test(key)) {
+        core.debug(`Skipping ${key} with regexp '${regexp}'`);
         return true;
       }
     }

--- a/tests/action/ChangeSet.test.js
+++ b/tests/action/ChangeSet.test.js
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { expect, should } from "chai";
 import sinon from "sinon";
 
 import ChangeSet from "../../src/action/ChangeSet.js";
@@ -68,8 +68,8 @@ describe("ChangeSet", () => {
     const descriptions = changeSet.changeDesc();
 
     expect(descriptions).to.deep.equal([
-      "SecretKey: [CHANGED] 'key1': 'value1' => 'new-value1'",
-      "SecretKey: [CHANGED] 'key2': 'value2' => 'new-value2'",
+      "SecretKey: [CHANGED] 'key1': '**********' => '**********'",
+      "SecretKey: [CHANGED] 'key2': '**********' => '**********'",
     ]);
   });
 
@@ -100,7 +100,9 @@ describe("ChangeSet", () => {
 
     const descriptions = changeSet.changeDesc();
 
-    expect(descriptions).to.deep.equal(["SecretKey: [ADDED] 'key3': 'value3'"]);
+    expect(descriptions).to.deep.equal([
+      "SecretKey: [ADDED] 'key3': '**********'",
+    ]);
   });
 
   it("should exclude keys from patterns", () => {
@@ -117,6 +119,31 @@ describe("ChangeSet", () => {
       newValues,
       existingValues,
       ["^_"],
+    );
+
+    const descriptions = changeSet.changeDesc();
+
+    expect(descriptions).to.deep.equal([
+      "SecretKey: [SKIP] '_excluded'",
+      "SecretKey: [ADDED] 'key3': '**********'",
+    ]);
+  });
+
+  it("should show real values on logs", () => {
+    const newValues = {
+      _excluded: "some",
+      key1: "value1",
+      key2: "value2",
+      key3: "value3",
+    };
+    const existingValues = { key1: "value1", key2: "value2" };
+
+    const changeSet = new ChangeSet(
+      secretsManagerStub,
+      newValues,
+      existingValues,
+      ["^_"],
+      true,
     );
 
     const descriptions = changeSet.changeDesc();

--- a/tests/action/ChangeSet.test.js
+++ b/tests/action/ChangeSet.test.js
@@ -102,4 +102,28 @@ describe("ChangeSet", () => {
 
     expect(descriptions).to.deep.equal(["SecretKey: [ADDED] 'key3': 'value3'"]);
   });
+
+  it("should exclude keys from patterns", () => {
+    const newValues = {
+      _excluded: "some",
+      key1: "value1",
+      key2: "value2",
+      key3: "value3",
+    };
+    const existingValues = { key1: "value1", key2: "value2" };
+
+    const changeSet = new ChangeSet(
+      secretsManagerStub,
+      newValues,
+      existingValues,
+      ["^_"],
+    );
+
+    const descriptions = changeSet.changeDesc();
+
+    expect(descriptions).to.deep.equal([
+      "SecretKey: [SKIP] '_excluded'",
+      "SecretKey: [ADDED] 'key3': 'value3'",
+    ]);
+  });
 });

--- a/tests/action/ChangeSet.test.js
+++ b/tests/action/ChangeSet.test.js
@@ -68,8 +68,8 @@ describe("ChangeSet", () => {
     const descriptions = changeSet.changeDesc();
 
     expect(descriptions).to.deep.equal([
-      "SecretKey: [CHANGE] 'key1': 'value1' => 'new-value1'",
-      "SecretKey: [CHANGE] 'key2': 'value2' => 'new-value2'",
+      "SecretKey: [CHANGED] 'key1': 'value1' => 'new-value1'",
+      "SecretKey: [CHANGED] 'key2': 'value2' => 'new-value2'",
     ]);
   });
 


### PR DESCRIPTION
## Description

Add new configurations to the action to make it more flexible

## Task Context

### What is the current behavior?

- Can't exclude specific keys y we dont want to sync it
- No visual help to understand what change on the sync
- No security bi showing the secret values all the time

### What is the new behavior?

- New configuration argument `exclude` that brings a regexp to exclude the matching keys on the json file
- Added colors to the logs to understand the changes on the sync
- by default all values are hiden by place holders and a new config arg `show_values` is added by default as false to show them if needed

### Additional Context

<!-- Add here any additional context you think is important. -->
