### PR TITLE
feat: add secret creation flag and flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Github action that sync an AWS Secrets Manager and it's values from a provided j
 
 - `secretsmanager:UpdateSecret`
 - `secretsmanager:GetSecretValue`
+- `secretsmanager:ListSecrets`
+- `secretsmanager:CreateSecret`
 
 ### Configuration
 
@@ -28,6 +30,7 @@ jobs:
           aws_region: <region>
           secret_name: <secret-name>
           json_file_path: path/to/json/secrets.json
+          create_secret: false # If true it will check if the secret exists or not to create it before execute sync (default false)
           dry_run: true # Default false
           show_values: false # If true secret values will be displayed on action logs (default false)
           exclude: '^_' # Regular expression that excludes the matching keys to be synced (default '^_')

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
   json_file_path:
     description: "Path to the JSON file containing secret data"
     required: true
+  create_secret:
+    description: "Flag to create the given secret if not exist before execute sync"
+    required: false
+    default: "false"
   dry_run:
     description: "Dry run mode (preview changes without modifying the secret)"
     required: false
@@ -32,10 +36,6 @@ inputs:
   exclude:
     description: "List of regular expressions that determines if a secret key should be excluded from sync"
     required: false
-
-outputs:
-  changes:
-    description: "List of changes made to the secret"
 
 runs:
   using: "docker"

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const getAction = () => {
     core.getInput("json_file_path"),
     core.getInput("exclude"),
     core.getBooleanInput("show_values"),
+    core.getBooleanInput("create_secret"),
   );
 };
 

--- a/src/secrets-manager/SecretsManager.js
+++ b/src/secrets-manager/SecretsManager.js
@@ -2,6 +2,8 @@ import {
   SecretsManagerClient,
   GetSecretValueCommand,
   UpdateSecretCommand,
+  CreateSecretCommand,
+  ListSecretsCommand,
 } from "@aws-sdk/client-secrets-manager";
 
 import lodash from "lodash";
@@ -53,5 +55,41 @@ export default class SecretsManager {
 
     const updateSecretCommand = new UpdateSecretCommand(updateSecretParams);
     await this.client.send(updateSecretCommand);
+  }
+
+  /**
+   * Assert if the given secrets name exists.
+   *
+   * @returns {boolean}
+   */
+  async exists() {
+    const listCommand = new ListSecretsCommand({
+      Filters: [
+        {
+          Key: "name",
+          Values: [this.secretName],
+        },
+      ],
+    });
+
+    const res = await this.client.send(listCommand);
+
+    if (res.SecretList.length > 0) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Create the given secret name with a default value
+   */
+  async create() {
+    const createCommand = new CreateSecretCommand({
+      Name: this.secretName,
+      SecretString: JSON.stringify({ generated: true }),
+    });
+
+    await this.client.send(createCommand);
   }
 }


### PR DESCRIPTION
## Description

Add feature to create secret manager if not exists before sync the values

## Task Context

### What is the current behavior?

- the secret manager instance should be created before execute sync action

### What is the new behavior?

- A new confing `create_secret` is added by default with false value. If true, the action will try to create the secret instance if not exists.

### Additional Context

<!-- Add here any additional context you think is important. -->
