### PR TITLE
feat: add build and publish in registry in relaese job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ env:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   bump_version:
@@ -21,14 +22,14 @@ jobs:
       version: ${{ steps.cz.outputs.version }}
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: "${{ secrets.ACCESS_TOKEN }}"
           ref: "main"
 
       - name: Set up Python
-        uses: actions/setup-python@v4.7.0
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: 3.11
 
@@ -57,3 +58,16 @@ jobs:
 
       - name: Print Version
         run: echo "Bumped to version ${{ steps.cz.outputs.version }}"
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛎 Checkout
+        uses: actions/checkout@v4
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to ghcr.io
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build and push
+        run: |
+          docker buildx build --platform linux/amd64,linux/arm64 -t $(echo "ghcr.io/${{ github.repository }}:latest" | tr '[:upper:]' '[:lower:]') --push .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM node:18
+FROM node:20
+
+LABEL "com.github.actions.icon"="blue"
+LABEL "com.github.actions.color"="database"
+LABEL "com.github.actions.name"="Sync AWS Secrets Manager"
+LABEL "com.github.actions.description"="Sync AWS Secrets Manager with a JSON file"
+LABEL "org.opencontainers.image.source"="https://github.com/Drafteame/sync-secrets-manager"
 
 COPY . /app
 WORKDIR /app

--- a/index.js
+++ b/index.js
@@ -16,6 +16,10 @@ const getAction = () => {
 
 const run = async () => {
   try {
+    setDefault("dry_run", "false");
+    setDefault("show_values", "false");
+    setDefault("create_secret", "false");
+
     const dryRun = core.getBooleanInput("dry_run");
 
     const changeSet = await getAction().run();
@@ -32,5 +36,13 @@ const run = async () => {
     core.setFailed(error.message);
   }
 };
+
+const setDefault = (name, value) => {
+  const envVarName = `INPUT_${name.replace(/ /g, '_').toUpperCase()}`;
+  const val = process.env[envVarName] || '';
+  if (val === '') {
+    process.env[envVarName] = value;
+  }
+}
 
 run();


### PR DESCRIPTION
## Description

Se agrega en el workflow de release el job para la publicación en el container Registry del repo.

Con esto nos ahorramos el tiempo de build de la imagen de Docker en los workflows de deploy ya que quedan previamente publicadas.

Se valida en dev:
![image](https://github.com/Drafteame/sync-secrets-manager/assets/57784749/258990d2-2903-4087-ae5d-1e9e5dcb3485)

Se agregan los valores default de los inputs booleans en el JS del action.
Al usarse la imagen desde el registry no toma los default del action.yml.

## Task Context

### What is the current behavior?

<!-- current functionality without PR -->

### What is the new behavior?

<!-- expected functionality with PR -->

### Additional Context

<!-- Add here any additional context you think is important. -->
